### PR TITLE
[BOOK-13]-회원가입 API 구현

### DIFF
--- a/src/main/java/goorm/unit/booklog/common/config/SecurityConfig.java
+++ b/src/main/java/goorm/unit/booklog/common/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
 		"/error",
 		"/favicon.ico",
 		"/index.html",
-			"/users", //회원가입 시 필요
+			"/api/v1/users/signup",
 	};
 
 	CorsConfigurationSource corsConfigurationSource() {

--- a/src/main/java/goorm/unit/booklog/common/config/SecurityConfig.java
+++ b/src/main/java/goorm/unit/booklog/common/config/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
 		"/error",
 		"/favicon.ico",
 		"/index.html",
+			"/users", //회원가입 시 필요
 	};
 
 	CorsConfigurationSource corsConfigurationSource() {

--- a/src/main/java/goorm/unit/booklog/domain/user/application/UserService.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/application/UserService.java
@@ -1,0 +1,38 @@
+package goorm.unit.booklog.domain.user.application;
+
+import goorm.unit.booklog.domain.user.domain.User;
+import goorm.unit.booklog.domain.user.presentation.request.UserCreateRequest;
+import goorm.unit.booklog.domain.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 아이디 중복 체크
+    public boolean isUsernameDuplicate(String id) {
+        return userRepository.existsById(id);
+    }
+
+    // 회원가입 로직
+    public String createUser(UserCreateRequest request) {
+
+        // 아이디 중복 체크
+        if (isUsernameDuplicate(request.getId())) {
+            throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+        }
+
+        // 비밀번호 암호화 후 저장
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        User user = new User(request.getId(),request.getName(), encodedPassword);
+        userRepository.save(user);
+
+        return user.getId();
+    }
+}
+

--- a/src/main/java/goorm/unit/booklog/domain/user/domain/User.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/domain/User.java
@@ -1,0 +1,46 @@
+package goorm.unit.booklog.domain.user.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+
+import goorm.unit.booklog.common.domain.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import org.springframework.security.core.userdetails.UserDetails;
+
+
+
+@AllArgsConstructor
+@NoArgsConstructor(access= AccessLevel.PROTECTED
+)
+@Getter
+@Entity
+public class User extends BaseTimeEntity {
+
+        @Id
+        @Column(nullable=false)
+        private String id;
+
+        @Column(nullable=false)
+        private String name;
+
+        @Column(nullable=false)
+        private String password;
+
+        //createdAt과 updatedAt은 BaseTimeEntity에서 자동으로 관리됨
+
+}

--- a/src/main/java/goorm/unit/booklog/domain/user/domain/User.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/domain/User.java
@@ -1,35 +1,28 @@
 package goorm.unit.booklog.domain.user.domain;
 
-import static jakarta.persistence.GenerationType.IDENTITY;
-
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 
 import goorm.unit.booklog.common.domain.BaseTimeEntity;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import org.springframework.security.core.userdetails.UserDetails;
 
 
-
-@AllArgsConstructor
-@NoArgsConstructor(access= AccessLevel.PROTECTED
-)
 @Getter
 @Entity
-public class User extends BaseTimeEntity {
+@Builder
+@Table(name="\"user\"")
+@AllArgsConstructor
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+
+public class User extends BaseTimeEntity implements UserDetails {
 
         @Id
         @Column(nullable=false)
@@ -41,6 +34,27 @@ public class User extends BaseTimeEntity {
         @Column(nullable=false)
         private String password;
 
-        //createdAt과 updatedAt은 BaseTimeEntity에서 자동으로 관리됨
+        public static User create(String id, String name, String password) {
+                return User.builder()
+                        .id(id)
+                        .name(name)
+                        .password(password)
+                        .build();
+        }
+
+        @Override
+        public Collection<? extends GrantedAuthority> getAuthorities() {
+                return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+        }
+
+        @Override
+        public String getUsername() {
+                return id;
+        }
+
+        @Override
+        public String getPassword(){
+                return password;
+        }
 
 }

--- a/src/main/java/goorm/unit/booklog/domain/user/domain/UserRepository.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/domain/UserRepository.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 
 public interface UserRepository {
     User save(User user);
+
     Optional<User> findById(String id);
+
     Boolean existsById(String id);
 }

--- a/src/main/java/goorm/unit/booklog/domain/user/domain/UserRepository.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/domain/UserRepository.java
@@ -1,0 +1,9 @@
+package goorm.unit.booklog.domain.user.domain;
+
+import java.util.Optional;
+
+public interface UserRepository {
+    User save(User user);
+    Optional<User> findById(String id);
+    Boolean existsById(String id);
+}

--- a/src/main/java/goorm/unit/booklog/domain/user/infrastructure/JpaUserRepository.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/infrastructure/JpaUserRepository.java
@@ -1,0 +1,8 @@
+package goorm.unit.booklog.domain.user.infrastructure;
+
+import goorm.unit.booklog.domain.user.domain.User;
+import goorm.unit.booklog.domain.user.domain.UserRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaUserRepository extends JpaRepository<User,String> {
+}

--- a/src/main/java/goorm/unit/booklog/domain/user/infrastructure/JpaUserRepository.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/infrastructure/JpaUserRepository.java
@@ -1,7 +1,6 @@
 package goorm.unit.booklog.domain.user.infrastructure;
 
 import goorm.unit.booklog.domain.user.domain.User;
-import goorm.unit.booklog.domain.user.domain.UserRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaUserRepository extends JpaRepository<User,String> {

--- a/src/main/java/goorm/unit/booklog/domain/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/infrastructure/UserRepositoryImpl.java
@@ -4,7 +4,6 @@ import goorm.unit.booklog.domain.user.domain.User;
 import goorm.unit.booklog.domain.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 
 @Repository
@@ -26,5 +25,4 @@ public class UserRepositoryImpl implements UserRepository {
     public Boolean existsById(String id) {
         return jpaUserRepository.existsById(id);
     }
-
 }

--- a/src/main/java/goorm/unit/booklog/domain/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/infrastructure/UserRepositoryImpl.java
@@ -1,0 +1,30 @@
+package goorm.unit.booklog.domain.user.infrastructure;
+
+import goorm.unit.booklog.domain.user.domain.User;
+import goorm.unit.booklog.domain.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+    private final JpaUserRepository jpaUserRepository;
+
+    @Override
+    public User save(User user) {
+        return jpaUserRepository.save(user);
+    }
+
+    @Override
+    public Optional<User> findById(String id) {
+        return jpaUserRepository.findById(id);
+    }
+
+    @Override
+    public Boolean existsById(String id) {
+        return jpaUserRepository.existsById(id);
+    }
+
+}

--- a/src/main/java/goorm/unit/booklog/domain/user/presentation/UserController.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/presentation/UserController.java
@@ -8,10 +8,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.parameters.P;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/users")  // 기본 경로 설정
@@ -27,5 +27,15 @@ public class UserController {
         String userId = userService.createUser(request);
         return new ResponseEntity<>(UserPersistResponse.of(userId), HttpStatus.CREATED);
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("code", "USERNAME_DUPLICATE");
+        errorResponse.put("message", ex.getMessage());  // 예외 메시지 사용 ("이미 존재하는 아이디입니다.")
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+
 }
 

--- a/src/main/java/goorm/unit/booklog/domain/user/presentation/UserController.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/presentation/UserController.java
@@ -1,0 +1,31 @@
+package goorm.unit.booklog.domain.user.presentation;
+
+import goorm.unit.booklog.domain.user.application.UserService;
+import goorm.unit.booklog.domain.user.presentation.request.UserCreateRequest;
+import goorm.unit.booklog.domain.user.presentation.response.UserPersistResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")  // 기본 경로 설정
+@RequiredArgsConstructor   // 의존성 주입을 위한 Lombok 어노테이션
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<UserPersistResponse> createUser(
+            @Valid @RequestBody UserCreateRequest request  // 요청 데이터를 검증 및 매핑
+    ) {
+        String userId = userService.createUser(request);
+        return new ResponseEntity<>(UserPersistResponse.of(userId), HttpStatus.CREATED);
+    }
+}
+

--- a/src/main/java/goorm/unit/booklog/domain/user/presentation/UserController.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/presentation/UserController.java
@@ -1,41 +1,48 @@
 package goorm.unit.booklog.domain.user.presentation;
 
+import goorm.unit.booklog.common.exception.ExceptionResponse;
 import goorm.unit.booklog.domain.user.application.UserService;
 import goorm.unit.booklog.domain.user.presentation.request.UserCreateRequest;
 import goorm.unit.booklog.domain.user.presentation.response.UserPersistResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
+import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
-@RequestMapping("/users")  // 기본 경로 설정
-@RequiredArgsConstructor   // 의존성 주입을 위한 Lombok 어노테이션
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+@Tag(name="User",description="유저 관리 api / 담당자 : 장선우")   // 의존성 주입을 위한 Lombok 어노테이션
 public class UserController {
-
     private final UserService userService;
 
-    @PostMapping
+    @Operation(summary="유저 생성", description="유저를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode="201",
+                    description="유저 생성 성공",
+                    content=@Content(schema=@Schema(implementation = UserPersistResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode="409",
+                    description="유저 생성 성공",
+                    content=@Content(schema=@Schema(implementation = ExceptionResponse.class))
+            )
+    })
+    @ResponseStatus(CREATED)
+    @PostMapping("/signup")
     public ResponseEntity<UserPersistResponse> createUser(
-            @Valid @RequestBody UserCreateRequest request  // 요청 데이터를 검증 및 매핑
+            @Valid @RequestBody UserCreateRequest request
     ) {
-        String userId = userService.createUser(request);
-        return new ResponseEntity<>(UserPersistResponse.of(userId), HttpStatus.CREATED);
+        UserPersistResponse response = userService.createUser(request);
+        return ResponseEntity.status(CREATED).body(response);
     }
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
-        Map<String, String> errorResponse = new HashMap<>();
-        errorResponse.put("code", "USERNAME_DUPLICATE");
-        errorResponse.put("message", ex.getMessage());  // 예외 메시지 사용 ("이미 존재하는 아이디입니다.")
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
-    }
-
-
 }
 

--- a/src/main/java/goorm/unit/booklog/domain/user/presentation/exception/UserExceptionCode.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/presentation/exception/UserExceptionCode.java
@@ -1,0 +1,26 @@
+package goorm.unit.booklog.domain.user.presentation.exception;
+
+import goorm.unit.booklog.common.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+@Getter
+@AllArgsConstructor
+public enum UserExceptionCode implements ExceptionCode {
+    USER_NOT_AUTHENTICATED(FORBIDDEN, "사용자 인증에 실패하였습니다."),
+    USER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    USER_ID_DUPLICATED(CONFLICT, "중복된 아이디 입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/src/main/java/goorm/unit/booklog/domain/user/presentation/exception/UserIdDuplicatedException.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/presentation/exception/UserIdDuplicatedException.java
@@ -1,0 +1,10 @@
+package goorm.unit.booklog.domain.user.presentation.exception;
+
+import goorm.unit.booklog.common.exception.CustomException;
+import static goorm.unit.booklog.domain.user.presentation.exception.UserExceptionCode.USER_ID_DUPLICATED;
+
+public class UserIdDuplicatedException extends CustomException {
+    public UserIdDuplicatedException() {
+        super(USER_ID_DUPLICATED);
+    }
+}

--- a/src/main/java/goorm/unit/booklog/domain/user/presentation/request/UserCreateRequest.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/presentation/request/UserCreateRequest.java
@@ -13,7 +13,7 @@ public record UserCreateRequest(
         @Pattern(regexp = "^[a-z0-9]+$", message = "아이디는 영문 소문자와 숫자로만 구성되어야 합니다.")
         String id,
 
-        @Schema(description = "이름",requiredMode = REQUIRED)
+        @Schema(description = "이름", example="홍길동", requiredMode = REQUIRED)
         @NotNull
         String name,
 

--- a/src/main/java/goorm/unit/booklog/domain/user/presentation/request/UserCreateRequest.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/presentation/request/UserCreateRequest.java
@@ -1,0 +1,34 @@
+package goorm.unit.booklog.domain.user.presentation.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UserCreateRequest {
+
+    @NotNull(message = "아이디를 입력해주세요.")
+    @Size(min = 4, max = 16, message = "아이디는 4자에서 16자 사이여야 합니다.")
+    @Pattern(regexp = "^[a-z0-9]+$", message = "아이디는 영문 소문자와 숫자로만 구성되어야 합니다.")
+    private String id;
+
+    @NotNull(message = "이름을 입력해주세요.")
+    private String name;
+
+    @NotNull(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z]).{8,}$", message = "비밀번호는 최소 8자리 이상, 영문자와 숫자를 포함해야 합니다.")
+    private String password;
+
+
+    // 생성자
+    public UserCreateRequest(String id, String name, String password) {
+        this.id = id;
+        this.name=name;
+        this.password = password;
+    }
+
+
+
+}
+

--- a/src/main/java/goorm/unit/booklog/domain/user/presentation/request/UserCreateRequest.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/presentation/request/UserCreateRequest.java
@@ -3,32 +3,23 @@ package goorm.unit.booklog.domain.user.presentation.request;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-@Getter
-public class UserCreateRequest {
+public record UserCreateRequest(
+        @Schema(description = "아이디", example = "id1234", requiredMode = REQUIRED)
+        @NotNull
+        @Size(min = 4, max = 16, message = "아이디는 4자에서 16자 사이여야 합니다.")
+        @Pattern(regexp = "^[a-z0-9]+$", message = "아이디는 영문 소문자와 숫자로만 구성되어야 합니다.")
+        String id,
 
-    @NotNull(message = "아이디를 입력해주세요.")
-    @Size(min = 4, max = 16, message = "아이디는 4자에서 16자 사이여야 합니다.")
-    @Pattern(regexp = "^[a-z0-9]+$", message = "아이디는 영문 소문자와 숫자로만 구성되어야 합니다.")
-    private String id;
+        @Schema(description = "이름",requiredMode = REQUIRED)
+        @NotNull
+        String name,
 
-    @NotNull(message = "이름을 입력해주세요.")
-    private String name;
-
-    @NotNull(message = "비밀번호를 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z]).{8,}$", message = "비밀번호는 최소 8자리 이상, 영문자와 숫자를 포함해야 합니다.")
-    private String password;
-
-
-    // 생성자
-    public UserCreateRequest(String id, String name, String password) {
-        this.id = id;
-        this.name=name;
-        this.password = password;
-    }
-
-
-
+        @Schema(description = "비밀번호", example = "password1234", requiredMode = REQUIRED)
+        @NotNull
+        @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z]).{8,}$", message = "비밀번호는 최소 8자리 이상, 영문자와 숫자를 포함해야 합니다.")
+        String password
+) {
 }
-

--- a/src/main/java/goorm/unit/booklog/domain/user/presentation/response/UserPersistResponse.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/presentation/response/UserPersistResponse.java
@@ -1,0 +1,7 @@
+package goorm.unit.booklog.domain.user.presentation.response;
+
+public record UserPersistResponse(String id) {
+    public static UserPersistResponse of(String id){
+        return new UserPersistResponse(id);
+    }
+}

--- a/src/main/java/goorm/unit/booklog/domain/user/presentation/response/UserPersistResponse.java
+++ b/src/main/java/goorm/unit/booklog/domain/user/presentation/response/UserPersistResponse.java
@@ -1,7 +1,13 @@
 package goorm.unit.booklog.domain.user.presentation.response;
 
-public record UserPersistResponse(String id) {
-    public static UserPersistResponse of(String id){
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UserPersistResponse(
+        @Schema(description = "유저 ID", example = "1", requiredMode = REQUIRED)
+        String id
+) {
+    public static UserPersistResponse of(String id) {
         return new UserPersistResponse(id);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,13 +8,16 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update #validate->update 변경, 기존 테이블은 유지하면서 필요한 변경사항만 적용.
       default_batch_fetch_size: 1000
       jdbc:
         time_zone: Asia/Seoul
     defer-datasource-initialization: true
     show-sql: true
     open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect  # 이 부분을 추가하세요
   data:
     redis:
       host: ${REDIS_HOST:localhost}


### PR DESCRIPTION
[BOOK-13]-회원가입 API 구현

## *⛳️ Work Description*
commit id : 9feb867f7dbc0ac07491ea13e5d006031b78d1fa
- user 도메인 폴더를 새롭게 생성하고, ddd 아키텍쳐에 맞게 회원가입 api를 구현하였습니다. 
- 아이디 중복 검사는 UserService에서 진행되고, 아이디와 비밀번호 형식에 대한 유효성 검사는 UserCreateRequest에서 진행됩니다. 
- SecurityConfig의 PERMIT_ALL_PATTERNS 에 "/users"를 추가하였습니다. 
- application.yml에서 ddl-auto를 validate에서 update로 변경하여, 특정 테이블이 아직 존재하지 않는 경우 테이블을 생성할 수 있게 하였습니다. 

commit id : 331d7ff498be939bd00c406e711c13bbe66b5239
- 아이디 중복 검사 실패 시 작동하는 exceptionhandler을 UserController에 따로 추가하였습니다.
- 변경 전 : {"code":"SERVER_ERROR","message":"예상치 못한 문제가 발생했습니다."}
- 변경 후 : {"code": "USERNAME_DUPLICATE","message": "이미 존재하는 아이디입니다."}


## *📸 Screenshot*

<img width="310" alt="Screenshot 2024-10-08 at 1 47 24 PM" src="https://github.com/user-attachments/assets/cfcba7e3-4e4c-481d-b727-fd3cd87aa678">
<img width="189" alt="Screenshot 2024-10-08 at 1 47 56 PM" src="https://github.com/user-attachments/assets/abb66c05-b7bf-4598-b9ef-2cc23bade9fa">
<img width="560" alt="Screenshot 2024-10-08 at 1 49 36 PM" src="https://github.com/user-attachments/assets/75770f0b-5825-461e-919f-e8bc17ba4631">
<img width="718" alt="Screenshot 2024-10-08 at 1 49 53 PM" src="https://github.com/user-attachments/assets/099dab52-4628-4cc8-95b1-3c7fc454b7d1">
<img width="494" alt="Screenshot 2024-10-08 at 2 03 23 PM" src="https://github.com/user-attachments/assets/0d7ef325-dba9-4048-a740-9c59d9824690">


*📢 To Reviewers*
- 