### PR TITLE
[BOOK-24]-독후감에서 multipart 파일을 첨부할 수 있도록 수정

### DIFF
--- a/src/main/java/goorm/unit/booklog/common/util/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/goorm/unit/booklog/common/util/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,32 @@
+package goorm.unit.booklog.common.util;
+
+import java.lang.reflect.Type;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+	public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+		super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+	}
+
+	@Override
+	public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+		return false;
+	}
+
+	@Override
+	public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+		return false;
+	}
+
+	@Override
+	protected boolean canWrite(MediaType mediaType) {
+		return false;
+	}
+}

--- a/src/main/java/goorm/unit/booklog/domain/book/application/BookService.java
+++ b/src/main/java/goorm/unit/booklog/domain/book/application/BookService.java
@@ -27,7 +27,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class BookService {
 	private final BookRepository bookRepository;
-	private final FileRepository fileRepository;
 
 	@Value("${naver.api.clientId}")
 	private String clientId;
@@ -64,23 +63,15 @@ public class BookService {
 			JSONObject item = items.getJSONObject(i);
 
 			Book book;
-			Long fileId;
 			String title = item.getString("title");
 			String author = item.getString("author");
 			String description=item.getString("description");
-			String link=item.getString("link");
+			String image = item.getString("image");
 
 			Optional<Book> existingBook = bookRepository.findByTitleAndAuthor(title, author);
-
-			if (!existingBook.isPresent()) {
-				File file = File.of(title, link);
-
-				book = Book.create(
-						title,
-						author,
-						description,
-						file
-				);
+			if (existingBook.isEmpty()) {
+				File file = File.of(title, image);
+				book = Book.create(title, author, description, file);
 				bookRepository.save(book);
 			}
 			else{
@@ -89,12 +80,9 @@ public class BookService {
 
 			BookResponse bookResponse = BookResponse.from(book);
 			bookResponses.add(bookResponse);
-
 		}
-
 		int total = jsonResponse.getInt("total");
 		return BookPageResponse.of(bookResponses, PageableResponse.of(PageRequest.of(page, size), (long)total));
-
 	}
 
 	public Book getBookById(Long id) {

--- a/src/main/java/goorm/unit/booklog/domain/book/application/BookService.java
+++ b/src/main/java/goorm/unit/booklog/domain/book/application/BookService.java
@@ -97,7 +97,7 @@ public class BookService {
 
 	}
 
-	public Book getBook(Long id) {
+	public Book getBookById(Long id) {
 		return bookRepository.findById(id).orElse(null);
 	}
 

--- a/src/main/java/goorm/unit/booklog/domain/book/presentation/response/BookResponse.java
+++ b/src/main/java/goorm/unit/booklog/domain/book/presentation/response/BookResponse.java
@@ -36,17 +36,17 @@ public record BookResponse(
 			.title(book.getTitle())
 			.author(book.getAuthor())
 			.description(book.getDescription())
-			.file(FileResponse.from(book.getFile()))
+			.file(FileResponse.of(book.getTitle(), book.getFile()))
 			.build();
 	}
 
-	public static BookResponse of (Long id, String title, String author, String description, File file) {
+	public static BookResponse of(Long id, String title, String author, String description, File file) {
 		return BookResponse.builder()
 			.id(id)
 			.title(title)
 			.author(author)
 			.description(description)
-			.file(FileResponse.from(file))
+			.file(FileResponse.of(title, file.getPhysicalPath()))
 			.build();
 	}
 }

--- a/src/main/java/goorm/unit/booklog/domain/file/presentation/response/FileResponse.java
+++ b/src/main/java/goorm/unit/booklog/domain/file/presentation/response/FileResponse.java
@@ -40,4 +40,11 @@ public record FileResponse(
 			.physicalPath(physicalPath)
 			.build();
 	}
+
+	public static FileResponse of (String title, File file) {
+		return FileResponse.builder()
+			.logicalName(title + " 대표 이미지")
+			.physicalPath(file.getPhysicalPath())
+			.build();
+	}
 }

--- a/src/main/java/goorm/unit/booklog/domain/file/presentation/response/FileResponse.java
+++ b/src/main/java/goorm/unit/booklog/domain/file/presentation/response/FileResponse.java
@@ -2,8 +2,6 @@ package goorm.unit.booklog.domain.file.presentation.response;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-import org.springframework.beans.factory.annotation.Value;
-
 import goorm.unit.booklog.domain.file.domain.File;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -20,17 +18,11 @@ public record FileResponse(
 	@Schema(description = "파일 경로", example = "https://example.com", requiredMode = REQUIRED)
 	String physicalPath
 ) {
-	@Value("${cloud.ncp.object-storage.credentials.endpoint}")
-	private static String endpoint;
-
-	@Value("${cloud.ncp.object-storage.credentials.bucket}")
-	private static String bucketName;
-
 	public static FileResponse from(File file) {
 		return FileResponse.builder()
 			.id(file.getId())
 			.logicalName(file.getLogicalName())
-			.physicalPath(endpoint + "/" + bucketName + "/" + file.getPhysicalPath())
+			.physicalPath("https://kr.object.ncloudstorage.com/booklog-bucket/" + file.getPhysicalPath())
 			.build();
 	}
 

--- a/src/main/java/goorm/unit/booklog/domain/review/domain/Review.java
+++ b/src/main/java/goorm/unit/booklog/domain/review/domain/Review.java
@@ -1,5 +1,6 @@
 package goorm.unit.booklog.domain.review.domain;
 
+import static goorm.unit.booklog.domain.review.domain.ReviewStatus.ACTIVE;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import java.time.LocalDateTime;
@@ -30,34 +31,33 @@ public class Review extends BaseTimeEntity {
     @Column(nullable = false, length = 2000)
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    private ReviewStatus status;
+
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "file_id")
     private File file;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 10)
-    private ReviewStatus status = ReviewStatus.ACTIVE; // 기본값 설정
-
-    @ManyToOne
-    @JoinColumn(name = "user_id",referencedColumnName = "id") // 외래 키 설정
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="book_id")
     private Book book;
 
-    public static Review create( String title, String content, File file,User user, Book book ) {
+    public static Review create( String title, String content, File file, User user, Book book) {
         return Review.builder()
-                .title(title)
-                .content(content)
-                .file(file)
-                .user(user)
-                .status(ReviewStatus.ACTIVE)
-                .book(book)
-                .build();
+            .title(title)
+            .content(content)
+            .status(ACTIVE)
+            .file(file)
+            .user(user)
+            .book(book)
+            .build();
     }
 
-    public void updateTitle( String title) {
+    public void updateTitle(String title) {
         this.title = title;
     }
 
@@ -65,8 +65,8 @@ public class Review extends BaseTimeEntity {
         this.content = content;
     }
 
-    public void updateBook( Book book ) {
-        this.book = book;
+    public void updateFile(File file) {
+        this.file = file;
     }
 
     public void updateStatus(ReviewStatus status) {

--- a/src/main/java/goorm/unit/booklog/domain/review/domain/ReviewRepository.java
+++ b/src/main/java/goorm/unit/booklog/domain/review/domain/ReviewRepository.java
@@ -3,9 +3,7 @@ package goorm.unit.booklog.domain.review.domain;
 import java.util.Optional;
 
 public interface ReviewRepository {
-
     Review save(Review review);
 
     Optional<Review> findById(Long id);
-
 }

--- a/src/main/java/goorm/unit/booklog/domain/review/domain/ReviewStatus.java
+++ b/src/main/java/goorm/unit/booklog/domain/review/domain/ReviewStatus.java
@@ -6,8 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ReviewStatus {
-    ACTIVE("활성화된 게시물 입니다."),
-    INACTIVE("삭제된 게시물 입니다.");
+    ACTIVE("활성화", "활성화된 게시물 입니다."),
+    INACTIVE("비활성화", "삭제되어 보이지 않는 게시물 입니다.");
 
-    private final String description;
+    private String key;
+    private String description;
 }

--- a/src/main/java/goorm/unit/booklog/domain/review/presentation/ReviewController.java
+++ b/src/main/java/goorm/unit/booklog/domain/review/presentation/ReviewController.java
@@ -3,6 +3,7 @@ package goorm.unit.booklog.domain.review.presentation;
 import goorm.unit.booklog.common.exception.ExceptionResponse;
 import goorm.unit.booklog.domain.review.application.ReviewService;
 import goorm.unit.booklog.domain.review.presentation.request.ReviewCreateRequest;
+import goorm.unit.booklog.domain.review.presentation.request.ReviewUpdateRequest;
 import goorm.unit.booklog.domain.review.presentation.response.ReviewPersistResponse;
 import goorm.unit.booklog.domain.review.presentation.response.ReviewResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,8 +17,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
@@ -30,72 +34,91 @@ public class ReviewController {
 
     @Operation(summary = "독후감 생성", description = "독후감을 생성합니다.")
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "201",
-                    description = "독후감 생성 성공",
-                    content = @Content(schema = @Schema(implementation = ReviewPersistResponse.class))
-            )
+        @ApiResponse(
+            responseCode = "201",
+            description = "독후감 생성 성공",
+            content = @Content(schema = @Schema(implementation = ReviewPersistResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "사용자 인증에 실패하였습니다.",
+            content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "해당 책이 존재하지 않습니다.",
+            content = @Content(schema = @Schema(implementation = ExceptionResponse.class))
+        )
     })
     @ResponseStatus(CREATED)
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ReviewPersistResponse> createReview(
-            @Valid @RequestBody ReviewCreateRequest request) {
-        ReviewPersistResponse response = reviewService.createReview(request);
+        @Parameter(description = "첨부 사진", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+        @RequestPart(value = "file", required = false) MultipartFile file,
+        @Parameter(description = "독후감 내용", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+        @Valid @RequestPart ReviewCreateRequest request
+    ) {
+        ReviewPersistResponse response = reviewService.createReview(file, request);
         return ResponseEntity.status(CREATED).body(response);
     }
 
     @Operation(summary = "독후감 조회", description = "review_id에 일치하는 독후감을 조회합니다.")
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "독후감 조회 성공",
-                    content = @Content(schema = @Schema(implementation = ReviewResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode="404",
-                    description="해당 reviewId가 존재하지 않습니다.",
-                    content=@Content(schema=@Schema(implementation = ExceptionResponse.class))
-            )
+        @ApiResponse(
+            responseCode = "200",
+            description = "독후감 조회 성공",
+            content = @Content(schema = @Schema(implementation = ReviewResponse.class))
+        ),
+        @ApiResponse(
+            responseCode="404",
+            description="해당 독후감이 존재하지 않습니다.",
+            content=@Content(schema=@Schema(implementation = ExceptionResponse.class))
+        )
     })
     @GetMapping("/{reviewId}")
     public ResponseEntity<ReviewResponse> getReview(
-            @Parameter(description = "독후감 ID", example = "1", required = true) @PathVariable("reviewId") @Positive Long reviewId) {
+            @Parameter(description = "독후감 ID", example = "1", required = true) @PathVariable("reviewId") @Positive Long reviewId
+    ) {
         ReviewResponse response = reviewService.getReview(reviewId);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "독후감 수정", description = "review_id에 일치하는 독후감을 수정합니다.")
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "독후감 수정 성공",
-                    content = @Content(schema = @Schema(implementation = ReviewResponse.class))
-            ),
-            @ApiResponse(
-                    responseCode="404",
-                    description="해당 reviewId가 존재하지 않습니다.",
-                    content=@Content(schema=@Schema(implementation = ExceptionResponse.class))
-            )
+        @ApiResponse(
+            responseCode = "200",
+            description = "독후감 수정 성공",
+            content = @Content(schema = @Schema(implementation = ReviewResponse.class))
+        ),
+        @ApiResponse(
+            responseCode="404",
+            description="해당 reviewId가 존재하지 않습니다.",
+            content=@Content(schema=@Schema(implementation = ExceptionResponse.class))
+        )
     })
-    @PatchMapping("/{reviewId}")
-    public ResponseEntity<ReviewResponse> updateReview(
-            @Parameter(description = "독후감 ID", example = "1", required = true) @PathVariable("reviewId") @Positive Long reviewId,
-            @Valid @RequestBody ReviewCreateRequest request) {
-        ReviewResponse response = reviewService.updateReview(reviewId,request);
-        return ResponseEntity.ok(response);
+    @PatchMapping(value = "/{reviewId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> updateReview(
+        @Parameter(description = "독후감 ID", example = "1", required = true) @PathVariable("reviewId") @Positive Long reviewId,
+        @Parameter(description = "첨부 사진", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+        @RequestPart(value = "file", required = false) MultipartFile file,
+        @Parameter(description = "독후감 내용", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+        @Valid @RequestPart ReviewUpdateRequest request
+    ) {
+        reviewService.updateReview(reviewId, file, request);
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "독후감 삭제", description = "review_id에 일치하는 독후감을 삭제합니다.")
     @ApiResponses({
-            @ApiResponse(
-                    responseCode = "200",
-                    description = "독후감 삭제 성공"
-            ),
-            @ApiResponse(
-                    responseCode="404",
-                    description="해당 reviewId가 존재하지 않습니다.",
-                    content=@Content(schema=@Schema(implementation = ExceptionResponse.class))
-            )
+        @ApiResponse(
+            responseCode = "200",
+            description = "독후감 삭제 성공"
+        ),
+        @ApiResponse(
+            responseCode="404",
+            description="해당 reviewId가 존재하지 않습니다.",
+            content=@Content(schema=@Schema(implementation = ExceptionResponse.class))
+        )
     })
     @PatchMapping("/delete/{reviewId}")
     public ResponseEntity<Void> deleteReview(@Parameter(description = "독후감 ID", example = "1", required = true) @PathVariable("reviewId") @Positive Long reviewId){

--- a/src/main/java/goorm/unit/booklog/domain/review/presentation/exception/ReviewExceptionCode.java
+++ b/src/main/java/goorm/unit/booklog/domain/review/presentation/exception/ReviewExceptionCode.java
@@ -10,7 +10,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @Getter
 @AllArgsConstructor
 public enum ReviewExceptionCode implements ExceptionCode {
-    REVIEW_NOT_FOUND(NOT_FOUND, "독후감을 찾을 수 없습니다."),;
+    REVIEW_NOT_FOUND(NOT_FOUND, "해당 독후감이 존재하지 않습니다."),;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/goorm/unit/booklog/domain/review/presentation/request/ReviewCreateRequest.java
+++ b/src/main/java/goorm/unit/booklog/domain/review/presentation/request/ReviewCreateRequest.java
@@ -1,43 +1,22 @@
 package goorm.unit.booklog.domain.review.presentation.request;
 
-import goorm.unit.booklog.domain.book.presentation.response.BookResponse;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-
 public record ReviewCreateRequest (
-        @Schema(description = "제목", example = "해리포터를 읽고", requiredMode = REQUIRED)
-        @NotNull
-        @Size(max = 50, message = "독후감 제목은 50자 이내여야합니다.")
-        String title,
+    @Schema(description = "제목", example = "해리포터를 읽고", requiredMode = REQUIRED)
+    @NotNull @Size(max = 50, message = "독후감 제목은 50자 이내여야합니다.")
+    String title,
 
-        @Schema(description = "본문", example="해리포터라는 책을 읽었다.", requiredMode = REQUIRED)
-        @NotNull
-        String content,
+    @Schema(description = "본문", example="해리포터라는 책을 읽었다.", requiredMode = REQUIRED)
+    @NotNull
+    String content,
 
-        @Schema(description = "썸네일 이미지", example = "", requiredMode = REQUIRED)
-        @NotNull
-        String img,
-
-        @Schema(description = "책 정보",
-                example = "{"
-                        + "\"id\": 1,"
-                        + "\"title\": \"어린 왕자\","
-                        + "\"author\": \"생텍쥐페리\","
-                        + "\"description\": \"책 어린왕자는 완전하지 못한 너와 내가 서로 어우러져 살아가는 방법에 대한 메시지를 전한다\","
-                        + "\"file\": {"
-                        + "    \"id\": 1,"
-                        + "    \"logicalName\": \"어린 왕자 대표 이미지\","
-                        + "    \"physicalPath\": \"https://search.shopping.naver.com/book/catalog/48953406622\""
-                        + "}"
-                        + "}",
-                requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
-        BookResponse bookResponse
-
+    @Schema(description = "도서 ID", example = "1", requiredMode = REQUIRED)
+    Long bookId
 ){
 
 }

--- a/src/main/java/goorm/unit/booklog/domain/review/presentation/request/ReviewUpdateRequest.java
+++ b/src/main/java/goorm/unit/booklog/domain/review/presentation/request/ReviewUpdateRequest.java
@@ -1,0 +1,18 @@
+package goorm.unit.booklog.domain.review.presentation.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ReviewUpdateRequest(
+	@Schema(description = "제목", example = "해리포터를 읽고", requiredMode = REQUIRED)
+	@NotNull @Size(max = 50, message = "독후감 제목은 50자 이내여야합니다.")
+	String title,
+
+	@Schema(description = "본문", example="해리포터라는 책을 읽었다.", requiredMode = REQUIRED)
+	@NotNull
+	String content
+) {
+}

--- a/src/main/java/goorm/unit/booklog/domain/review/presentation/response/ReviewPersistResponse.java
+++ b/src/main/java/goorm/unit/booklog/domain/review/presentation/response/ReviewPersistResponse.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 public record ReviewPersistResponse(
-        @Schema(description = "독후감 아이디", example = "1", requiredMode = REQUIRED)
-        Long id
+    @Schema(description = "독후감 아이디", example = "1", requiredMode = REQUIRED)
+    Long id
 )
 {
     public static ReviewPersistResponse of(Long id) {

--- a/src/main/java/goorm/unit/booklog/domain/review/presentation/response/ReviewResponse.java
+++ b/src/main/java/goorm/unit/booklog/domain/review/presentation/response/ReviewResponse.java
@@ -2,49 +2,63 @@ package goorm.unit.booklog.domain.review.presentation.response;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-import io.swagger.v3.oas.annotations.media.Schema;
-import goorm.unit.booklog.domain.review.domain.Review;
-import org.springframework.format.annotation.DateTimeFormat;
+
 import java.time.format.DateTimeFormatter;
 
+import org.springframework.format.annotation.DateTimeFormat;
 
+import goorm.unit.booklog.domain.book.presentation.response.BookResponse;
+import goorm.unit.booklog.domain.file.presentation.response.FileResponse;
+import goorm.unit.booklog.domain.review.domain.Review;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
 public record ReviewResponse(
-        @Schema(
-                description = "게시물 썸네일",
-                example = "https://example.domain.com/files/example.jpg",
-                requiredMode = REQUIRED)
-        String thumbImg,
+        @Schema(description = "독후감 ID", example = "1", requiredMode = REQUIRED)
+        Long id,
 
         @Schema(description = "독후감 제목", example = "해리포터를 읽고", requiredMode = REQUIRED)
         String title,
 
-        @Schema(description = "작성자 이름", example = "홍길동", requiredMode = REQUIRED)
-        String name,
-
         @Schema(description = "독후감 본문", example = "이번 기회에 해리포터라는 책을 읽게 되었다.", requiredMode = NOT_REQUIRED)
         String content,
 
-        @Schema(description = "책 제목", example = "해리포터", requiredMode = NOT_REQUIRED)
-        String book_name,
+        @Schema(description = "작성자 이름", example = "홍길동", requiredMode = REQUIRED)
+        String name,
 
-        @Schema(description = "작성 일자", example = "2024-10-10", requiredMode = NOT_REQUIRED)
+        @Schema(
+            description = "독후감 사진",
+            example = "{\"id\": 1, \"logicalName\": \"example.jpg\", \"physicalPath\": \"https://example-bucket.ncp.com/files/example.jpg\"}",
+            requiredMode = NOT_REQUIRED)
+        FileResponse file,
+
+        @Schema(
+            description = "도서 목록",
+            example = "{\"id\": 1, \"title\": \"스프링 부트와 AWS로 혼자 구현하는 웹 서비스\", \"author\": \"이한음\", \"description\": \"스프링 부트와 AWS로 혼자 구현하는 웹 서비스\", \"file\": {\"id\": 1, \"logicalName\": \"example.jpg\", \"physicalPath\": \"https://example-bucket.ncp.com/files/example.jpg\"}}",
+            requiredMode = REQUIRED
+        )
+        BookResponse book,
+
+        @Schema(description = "작성 일자", example = "2024-10-10", requiredMode = REQUIRED)
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         String createdAt,
 
-        @Schema(description = "수정 일자", example = "2024-10-10", requiredMode = NOT_REQUIRED)
+        @Schema(description = "수정 일자", example = "2024-10-10", requiredMode = REQUIRED)
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         String updatedAt
 ) {
     public static ReviewResponse of(Review review) {
         DateTimeFormatter formatter=DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        return new ReviewResponse(
-                review.getFile().getPhysicalPath(),
-                review.getTitle(),
-                review.getUser().getName(),
-                review.getContent(),
-                review.getBook().getTitle(),
-                review.getCreatedAt().format(formatter),
-                review.getUpdatedAt().format(formatter)
-                );
+        return ReviewResponse.builder()
+            .id(review.getId())
+            .title(review.getTitle())
+            .name(review.getUser().getName())
+            .content(review.getContent())
+            .file(review.getFile() != null ? FileResponse.from(review.getFile()) : null)
+            .book(BookResponse.from(review.getBook()))
+            .createdAt(review.getCreatedAt().format(formatter))
+            .updatedAt(review.getUpdatedAt().format(formatter))
+            .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
+  servlet:
+    multipart:
+      maxFileSize: 5MB
+
   data:
     redis:
       host: ${REDIS_HOST:localhost}


### PR DESCRIPTION
### 📍[BOOK-24]-독후감에서 multipart 파일을 첨부할 수 있도록 수정

## *⛳️ Work Description*
- 독후감 생성, 수정 시에 multipart 파일을 첨부할 수 있도록 변경하였습니다.
- 도서를 저장할 때 상품 판매 링크를 이미지 url로 저장하는 문제를 해결하였습니다.
- object storage의 버킷 엔드포인트를 하드코딩하는 방향으로 변경하였습니다.

## *📸 Screenshot*
<img width="1414" alt="스크린샷 2024-10-11 오후 3 41 50" src="https://github.com/user-attachments/assets/32fa1d96-49da-42ab-8314-227d28d73bf8">
<img width="1404" alt="스크린샷 2024-10-11 오후 3 42 14" src="https://github.com/user-attachments/assets/0493fe33-fb4d-4887-91af-ff3c3415f96f">


## *📢 To Reviewers*
- 